### PR TITLE
Require component-cookie dynamically

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@
  * Module dependencies
  */
 
-const cookie = require('component-cookie')
 const parser = require('cookie')
 
 /**
@@ -24,6 +23,6 @@ function Cookies (ctx, options) {
     return parser.parse(cookies, options)
   } else {
     // browser
-    return cookie()
+    return require('component-cookie')();
   }
 }


### PR DESCRIPTION
The current code was causing issues in the browser with next@3.0.1-beta.19. Was getting an error on client side page changes:

```
Can't find variable: cookie
Cookies
_callee$
tryCatch
invoke
step
Promise

tryCatch
invoke
step
Promise

tryCatch
invoke
step
Promise

tryCatch
invoke
step
Promise

tryCatch
invoke
step
Promise
```

I'm not sure if this is the best fix, but doing the require dynamically fixes the bug. Perhaps this is next related as well. (also hi matt it's been a long time : ) 👋  )