### PR TITLE
add repo field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "1.0.2",
   "description": "get the cookies on both the client & server",
   "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/matthewmueller/next-cookies.git"
+  },
   "scripts": {
     "test": "make test"
   },


### PR DESCRIPTION
it's nice to easily find the repo when browsing packages on npm. this enables that =]