### PR TITLE
Bumps component-cookie to ^1.1.4 (to bump debug)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "Matthew Mueller",
   "license": "MIT",
   "dependencies": {
-    "component-cookie": "^1.1.3",
+    "component-cookie": "^1.1.4",
     "cookie": "^0.3.1"
   },
   "browser": {


### PR DESCRIPTION
debug released breaking changes in 4.0.0
component-cookie did not fix its dependency on debug until 1.1.4