### PR TITLE
allow for headers to be undefined during export

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ function Cookies (ctx, options) {
   options = options || {}
   if (ctx.req) {
     // server
-    const cookies = ctx.req.headers.cookie
+    const cookies = ctx.req.headers && ctx.req.headers.cookie
     if (!cookies) return {}
     return parser.parse(cookies, options)
   } else {


### PR DESCRIPTION
This is a workaround for https://github.com/zeit/next.js/issues/5456 - during export, with next.js 7.0.1, `ctx.req.headers` is undefined