### PR TITLE
Fix TypeError: Cannot read property 'req' of undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = Cookies
 
 function Cookies (ctx, options) {
   options = options || {}
-  if (ctx.req) {
+  if (ctx && ctx.req) {
     // server
     if (!ctx.req.headers) return {} // for Static export feature of Next.js
     const cookies = ctx.req.headers.cookie


### PR DESCRIPTION
If I try to use it in the browser I get the error because in the browser `ctx` is undefined and we need to check for that before checking if `ctx.req` is defined.